### PR TITLE
Groundwork for using npm scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,7 +159,7 @@ Contribute by making edits in [`/src`](./src) or reporting [issues](../../issues
 
 ```sh
 npm install
-grunt jshint:src
+npm test
 ```
 
 ## Fund

--- a/README.md
+++ b/README.md
@@ -62,15 +62,15 @@ verge.inViewport(elem, -100) // true if elem is in the current viewport and not 
 verge.inViewport(elem) === verge.inX(elem) && verge.inY(elem) // always true
 ```
 
-##### Substitute [inViewport](#inviewport) with: [inY](#iny) on *vertical* sites, [inX](#inx) on *horizontal* ones. 
+##### Substitute [inViewport](#inviewport) with: [inY](#iny) on *vertical* sites, [inX](#inx) on *horizontal* ones.
 
-- On pages without horizontal scroll, [inX](#inx) is always `true`. 
-- On pages without vertical scroll, [inY](#iny) is always `true`. 
+- On pages without horizontal scroll, [inX](#inx) is always `true`.
+- On pages without vertical scroll, [inY](#iny) is always `true`.
 - If the viewport width is `>=` the `document` width, then [inX](#inx) is always `true`.
 
 ### .inX()
 
-Test if any part of an element (or the first element in a matched set) is in the same x-axis section as the viewport. Returns **boolean**. 
+Test if any part of an element (or the first element in a matched set) is in the same x-axis section as the viewport. Returns **boolean**.
 
 ```js
 verge.inX(elem) // true if elem is in same x-axis as the viewport (exact)
@@ -119,7 +119,7 @@ verge.mq('tv') // -> boolean
 
 Get an a <b>object</b> containing the properties `top`, `bottom`, `left`, `right`, `width`, and `height` with respect to the top-left corner of the current viewport, and with an optional cushion amount. Its return is like that of the native [getBoundingClientRect](https://developer.mozilla.org/en/DOM/element.getBoundingClientRect).
 
-The optional <b>cushion</b> parameter is an amount of pixels to act as a cushion around the element. If none is provided then it defaults to `0` and the rectangle will match the native rectangle. If a cushion is specified, the properties are adjusted according to the cushion amount. If the cushion is **positive** the rectangle will represent an area that is larger that the actual element. If the cushion is **negative** then the rectangle will represent an area that is **smaller** that the actual element. 
+The optional <b>cushion</b> parameter is an amount of pixels to act as a cushion around the element. If none is provided then it defaults to `0` and the rectangle will match the native rectangle. If a cushion is specified, the properties are adjusted according to the cushion amount. If the cushion is **positive** the rectangle will represent an area that is larger that the actual element. If the cushion is **negative** then the rectangle will represent an area that is **smaller** that the actual element.
 
 ```js
 verge.rectangle(element) // rectangle object
@@ -150,7 +150,7 @@ jQuery.extend(verge)
 
 
 ```sh
-$ ender build verge
+ender build verge
 ```
 
 ## Contribute
@@ -158,8 +158,8 @@ $ ender build verge
 Contribute by making edits in [`/src`](./src) or reporting [issues](../../issues).
 
 ```sh
-$ npm install
-$ grunt jshint:src
+npm install
+grunt jshint:src
 ```
 
 ## Fund

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
   "main": "./verge.js",
   "ender": "./src/ender.js",
   "scripts": {
+    "preversion": "npm test",
     "test": "grunt jshint:src"
   },
   "repository": {

--- a/package.json
+++ b/package.json
@@ -8,10 +8,13 @@
   "keywords": ["viewport", "dimensions", "responsive", "media queries", "ender"],
   "main": "./verge.js",
   "ender": "./src/ender.js",
+  "scripts": {
+    "test": "grunt jshint:src"
+  },
   "repository": {
     "type": "git",
     "url": "https://github.com/ryanve/verge.git"
-  }, 
+  },
   "devDependencies": {
     "grunt": "~0.4.2",
     "grunt-contrib-uglify": "~0.3.0",


### PR DESCRIPTION
Prefer using `npm test` over `grunt jshint:src`  because this moves us closer to [the new structure](https://github.com/ryanve/verge/issues/25)