### PR TITLE
Revert path change for now to be extra safe

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,8 +5,8 @@
   "homepage": "https://github.com/ryanve/verge",
   "license": "MIT",
   "author": "Ryan Van Etten",
-  "main": "verge.js",
-  "ender": "src/ender.js",
+  "main": "./verge.js",
+  "ender": "./src/ender.js",
   "scripts": {
     "preversion": "npm test",
     "test": "grunt jshint:src"


### PR DESCRIPTION
This reverts [the path change](https://github.com/ryanve/verge/pull/32/files) for now just in case somehow this could be breaking for someone. 