### PR TITLE
Fix grunt uglify subarray warning

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   },
   "devDependencies": {
     "grunt": "0.4.5",
-    "grunt-contrib-uglify": "0.3.0",
+    "grunt-contrib-uglify": "0.6.0",
     "grunt-contrib-concat": "0.3.0",
     "grunt-contrib-jshint": "0.8.0"
   },

--- a/package.json
+++ b/package.json
@@ -19,10 +19,10 @@
     "url": "https://github.com/ryanve/verge/issues"
   },
   "devDependencies": {
-    "grunt": "~0.4.2",
-    "grunt-contrib-uglify": "~0.3.0",
-    "grunt-contrib-concat": "~0.3.0",
-    "grunt-contrib-jshint": "~0.8.0"
+    "grunt": "0.4.5",
+    "grunt-contrib-uglify": "0.3.0",
+    "grunt-contrib-concat": "0.3.0",
+    "grunt-contrib-jshint": "0.8.0"
   },
   "keywords": [
     "width",


### PR DESCRIPTION
Fixes

> Gzipped:  Warning: Cannot create property 'subarray' on string '/*!

It was [due to uglify version range used by the plugin](https://github.com/gruntjs/grunt-contrib-uglify/pull/314) 